### PR TITLE
docs: add README for OctoAcme Project Management documentation

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,24 @@
+# OctoAcme Project Management Documentation
+
+Welcome to the Project Management Docs for OctoAcme. Here you will find process guides and best practices for all phases of our project delivery lifecycle.
+
+## OctoAcme Project Management Overview
+
+OctoAcme follows a structured five-stage project lifecycle: **Initiation**, **Planning**, **Execution**, **Release**, and **Close & Retrospective**. During initiation, teams validate business needs and create a lightweight Project One-pager that captures the problem statement, success metrics, stakeholders, and initial timeline. Once approved by the Product Lead and sponsors, the project moves to planning, where work is broken into shippable increments, backlog items are prioritized with acceptance criteria, and dependencies are identified. Throughout execution, teams follow an iterative delivery model using a project board with columns (Backlog, Ready, In Progress, In Review, QA, Done) and conduct daily standups, weekly delivery syncs, and sprint-based planning. Small pull requests (≤400 lines) with automated CI testing and required approvals ensure quality before merging. Finally, releases are managed through a standardized checklist that includes passing security scans, smoke testing in staging, deployment to production, and post-deploy verification.
+
+OctoAcme defines four core personas that collaborate throughout the project lifecycle: **Project Managers** coordinate schedules, risks, communications, and maintain transparency across stakeholders; **Product Managers** define what to build, prioritize the backlog, and measure outcomes against success metrics; **Developers** implement features, write tests, and participate in design and code reviews; and **QA/Testing** professionals validate quality and acceptance criteria. Clear ownership is emphasized—each project has a named PM and Product Lead—enabling accountability and reducing confusion about decision-making authority.
+
+Communication cadence is structured and regular: weekly syncs between PM and Product Manager, twice-weekly standups for delivery teams, and monthly stakeholder updates via a single source of truth (project README or release doc). Risk management is proactive, with a Risk Register capturing ID, description, impact, likelihood, owner, and mitigation plan. Risks are reviewed and updated weekly during syncs, with a three-level escalation path (team → PM → Product Lead → Sponsor) for blockers that need executive attention. For incidents, teams follow a blameless retrospective approach and use standardized communication templates to keep stakeholders informed.
+
+Quality is woven throughout execution with unit tests for new logic, integration tests where applicable, end-to-end smoke tests before release, and security scanning in CI pipelines. Manual QA validates feature acceptance when needed. After each sprint, release, or milestone, teams hold retrospectives to capture learnings and identify 2–3 prioritized action items for continuous improvement. These action items are tracked in the project backlog with clear owners and due dates, ensuring that process improvements are measured and celebrated, fostering a culture of psychological safety and iterative refinement.
+
+## Project Management Process Docs
+
+- [Project Management Overview](octoacme-project-management-overview.md)
+- [Project Initiation](octoacme-project-initiation.md)
+- [Project Planning](octoacme-project-planning.md)
+- [Execution and Tracking](octoacme-execution-and-tracking.md)
+- [Risks and Communication](octoacme-risks-and-communication.md)
+- [Release and Deployment](octoacme-release-and-deployment.md)
+- [Retrospective and Continuous Improvement](octoacme-retrospective-and-continuous-improvement.md)
+- [Roles and Personas](octoacme-roles-and-personas.md)


### PR DESCRIPTION
This PR adds a central README to the \`docs/\` folder that provides an overview of OctoAcme's project management processes and links to all process documentation.

## Changes
- Added \`docs/README.md\` with process overview and navigation links
- Overview summarizes key workflows, personas, communication strategies, and quality assurance practices

## Acceptance Criteria
- [x] Content aligns with existing process docs
- [x] Update improves clarity and discoverability
- [x] Content reviewed against all process documentation"